### PR TITLE
Silence a bunch of Swift 5 warnings about redundant modifiers

### DIFF
--- a/PopupDialog/Classes/PopupDialog+Keyboard.swift
+++ b/PopupDialog/Classes/PopupDialog+Keyboard.swift
@@ -34,7 +34,7 @@ internal extension PopupDialog {
     // MARK: - Keyboard & orientation observers
 
     /*! Add obserservers for UIKeyboard notifications */
-    internal func addObservers() {
+    func addObservers() {
         NotificationCenter.default.addObserver(self, selector: #selector(orientationChanged),
                                                          name: UIDevice.orientationDidChangeNotification,
                                                          object: nil)
@@ -56,7 +56,7 @@ internal extension PopupDialog {
     }
 
     /*! Remove observers */
-    internal func removeObservers() {
+    func removeObservers() {
         NotificationCenter.default.removeObserver(self,
                                                             name: UIDevice.orientationDidChangeNotification,
                                                             object: nil)

--- a/PopupDialog/Classes/PopupDialogDefaultViewController.swift
+++ b/PopupDialog/Classes/PopupDialogDefaultViewController.swift
@@ -44,7 +44,7 @@ public extension PopupDialogDefaultViewController {
     // MARK: Content
 
     /// The dialog image
-    public var image: UIImage? {
+    var image: UIImage? {
         get { return standardView.imageView.image }
         set {
             standardView.imageView.image = newValue
@@ -53,7 +53,7 @@ public extension PopupDialogDefaultViewController {
     }
 
     /// The title text of the dialog
-    public var titleText: String? {
+    var titleText: String? {
         get { return standardView.titleLabel.text }
         set {
             standardView.titleLabel.text = newValue
@@ -62,7 +62,7 @@ public extension PopupDialogDefaultViewController {
     }
 
     /// The message text of the dialog
-    public var messageText: String? {
+    var messageText: String? {
         get { return standardView.messageLabel.text }
         set {
             standardView.messageLabel.text = newValue
@@ -73,7 +73,7 @@ public extension PopupDialogDefaultViewController {
     // MARK: Appearance
 
     /// The font and size of the title label
-    @objc public dynamic var titleFont: UIFont {
+    @objc dynamic var titleFont: UIFont {
         get { return standardView.titleFont }
         set {
             standardView.titleFont = newValue
@@ -82,7 +82,7 @@ public extension PopupDialogDefaultViewController {
     }
 
     /// The color of the title label
-    @objc public dynamic var titleColor: UIColor? {
+    @objc dynamic var titleColor: UIColor? {
         get { return standardView.titleLabel.textColor }
         set {
             standardView.titleColor = newValue
@@ -91,7 +91,7 @@ public extension PopupDialogDefaultViewController {
     }
 
     /// The text alignment of the title label
-    @objc public dynamic var titleTextAlignment: NSTextAlignment {
+    @objc dynamic var titleTextAlignment: NSTextAlignment {
         get { return standardView.titleTextAlignment }
         set {
             standardView.titleTextAlignment = newValue
@@ -100,7 +100,7 @@ public extension PopupDialogDefaultViewController {
     }
 
     /// The font and size of the body label
-    @objc public dynamic var messageFont: UIFont {
+    @objc dynamic var messageFont: UIFont {
         get { return standardView.messageFont}
         set {
             standardView.messageFont = newValue
@@ -109,7 +109,7 @@ public extension PopupDialogDefaultViewController {
     }
 
     /// The color of the message label
-    @objc public dynamic var messageColor: UIColor? {
+    @objc dynamic var messageColor: UIColor? {
         get { return standardView.messageColor }
         set {
             standardView.messageColor = newValue
@@ -118,7 +118,7 @@ public extension PopupDialogDefaultViewController {
     }
 
     /// The text alignment of the message label
-    @objc public dynamic var messageTextAlignment: NSTextAlignment {
+    @objc dynamic var messageTextAlignment: NSTextAlignment {
         get { return standardView.messageTextAlignment }
         set {
             standardView.messageTextAlignment = newValue
@@ -126,7 +126,7 @@ public extension PopupDialogDefaultViewController {
         }
     }
     
-    public override func viewDidLayoutSubviews() {
+    override func viewDidLayoutSubviews() {
         super.viewDidLayoutSubviews()
         standardView.imageHeightConstraint?.constant = standardView.imageView.pv_heightForImageView()
     }

--- a/PopupDialog/Classes/UIImageView+Calculations.swift
+++ b/PopupDialog/Classes/UIImageView+Calculations.swift
@@ -33,7 +33,7 @@ internal extension UIImageView {
      have so the image is displayed correctly
      - returns: Height to set on the imageView
      */
-    internal func pv_heightForImageView() -> CGFloat {
+    func pv_heightForImageView() -> CGFloat {
         guard let image = image, image.size.height > 0 else {
             return 0.0
         }

--- a/PopupDialog/Classes/UIView+Animations.swift
+++ b/PopupDialog/Classes/UIView+Animations.swift
@@ -39,10 +39,10 @@ internal enum AnimationDirection {
 internal extension UIView {
 
     /// The key for the fade animation
-    internal var fadeKey: String { return "FadeAnimation" }
-    internal var shakeKey: String { return "ShakeAnimation" }
+    var fadeKey: String { return "FadeAnimation" }
+    var shakeKey: String { return "ShakeAnimation" }
 
-    internal func pv_fade(_ direction: AnimationDirection, _ value: Float, duration: CFTimeInterval = 0.08) {
+    func pv_fade(_ direction: AnimationDirection, _ value: Float, duration: CFTimeInterval = 0.08) {
         layer.removeAnimation(forKey: fadeKey)
         let animation = CABasicAnimation(keyPath: "opacity")
         animation.duration = duration
@@ -52,7 +52,7 @@ internal extension UIView {
         layer.add(animation, forKey: fadeKey)
     }
 
-    internal func pv_layoutIfNeededAnimated(duration: CFTimeInterval = 0.08) {
+    func pv_layoutIfNeededAnimated(duration: CFTimeInterval = 0.08) {
         UIView.animate(withDuration: duration, delay: 0, options: UIView.AnimationOptions(), animations: {
             self.layoutIfNeeded()
         }, completion: nil)
@@ -60,7 +60,7 @@ internal extension UIView {
     
     // As found at https://gist.github.com/mourad-brahim/cf0bfe9bec5f33a6ea66#file-uiview-animations-swift-L9
     // Slightly modified
-    internal func pv_shake() {
+    func pv_shake() {
         layer.removeAnimation(forKey: shakeKey)
         let vals: [Double] = [-2, 2, -2, 2, 0]
         

--- a/PopupDialog/Classes/UIViewController+Visibility.swift
+++ b/PopupDialog/Classes/UIViewController+Visibility.swift
@@ -29,18 +29,18 @@ import UIKit
 // http://stackoverflow.com/questions/2777438/how-to-tell-if-uiviewcontrollers-view-is-visible
 internal extension UIViewController {
 
-    internal var isTopAndVisible: Bool {
+    var isTopAndVisible: Bool {
         return isVisible && isTopViewController
     }
 
-    internal var isVisible: Bool {
+    var isVisible: Bool {
         if isViewLoaded {
             return view.window != nil
         }
         return false
     }
 
-    internal var isTopViewController: Bool {
+    var isTopViewController: Bool {
         if self.navigationController != nil {
             return self.navigationController?.visibleViewController === self
         } else if self.tabBarController != nil {


### PR DESCRIPTION
This fixes 21 totally useless warnings due to the (freshly removed) modifiers being redundant. (These warnings couldn't be silenced in the main iOS project because we compile the Swift files directly, rather than being in a separate module.)